### PR TITLE
Fix typo in macOS font matching comment

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -326,7 +326,7 @@ function configureCommandlineSwitchesSync(cliArgs: NativeParsedArgs) {
 	app.commandLine.appendSwitch('disable-features', featuresToDisable);
 
 	// Blink features to configure.
-	// `FontMatchingCTMigration` - Siwtch font matching on macOS to Appkit (Refs https://github.com/microsoft/vscode/issues/224496#issuecomment-2270418470).
+        // `FontMatchingCTMigration` - Switch font matching on macOS to Appkit (Refs https://github.com/microsoft/vscode/issues/224496#issuecomment-2270418470).
 	// `StandardizedBrowserZoom` - Disable zoom adjustment for bounding box (https://github.com/microsoft/vscode/issues/232750#issuecomment-2459495394)
 	const blinkFeaturesToDisable =
 		`FontMatchingCTMigration,StandardizedBrowserZoom,${app.commandLine.getSwitchValue('disable-blink-features')}`;


### PR DESCRIPTION
## Summary
- correct a typo in `src/main.ts`

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6876fb66cba8832687086cf4bd0ea9f8