### PR TITLE
Fix comment typo in app.ts

### DIFF
--- a/src/vs/code/electron-main/app.ts
+++ b/src/vs/code/electron-main/app.ts
@@ -418,7 +418,7 @@ export class CodeApplication extends Disposable {
 			// For all other URLs, delegate to the OS.
 			contents.setWindowOpenHandler(details => {
 
-				// about:blank windows can open as window witho our default options
+                                // about:blank windows can open as window with our default options
 				if (details.url === 'about:blank') {
 					this.logService.trace('[aux window] webContents#setWindowOpenHandler: Allowing auxiliary window to open on about:blank');
 


### PR DESCRIPTION
## Summary
- fix a small typo in `src/vs/code/electron-main/app.ts`

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_6876fb6504708326a70d2958fa324520