### PR TITLE
Add minimal FastAPI auth backend

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,3 +21,5 @@ vscode.db
 product.overrides.json
 *.snap.actual
 .vscode-test
+.env
+__pycache__/

--- a/README.md
+++ b/README.md
@@ -57,6 +57,10 @@ Many of the core components and extensions to VS Code live in their own reposito
 
 VS Code includes a set of built-in extensions located in the [extensions](extensions) folder, including grammars and snippets for many languages. Extensions that provide rich language support (code completion, Go to Definition) for a language have the suffix `language-features`. For example, the `json` extension provides coloring for `JSON` and the `json-language-features` extension provides rich language support for `JSON`.
 
+## Backend API
+
+A simple FastAPI backend lives in `backend/main.py`. Install dependencies with `pip install -r requirements.txt`.
+Set `SECRET_TOKEN` in a `.env` file and run the server with `uvicorn backend.main:app`. Requests to `/secure` require a `Bearer` token.
 ## Development Container
 
 This repository includes a Visual Studio Code Dev Containers / GitHub Codespaces development container.

--- a/backend/main.py
+++ b/backend/main.py
@@ -1,0 +1,32 @@
+from fastapi import FastAPI, Depends, HTTPException, status
+from fastapi.security import HTTPBearer, HTTPAuthorizationCredentials
+from dotenv import load_dotenv
+import os
+
+load_dotenv()
+
+SECRET_TOKEN = os.getenv("SECRET_TOKEN")
+if not SECRET_TOKEN:
+    raise RuntimeError("SECRET_TOKEN not set in environment")
+
+app = FastAPI()
+security = HTTPBearer()
+
+
+def verify_token(credentials: HTTPAuthorizationCredentials = Depends(security)):
+    if credentials.credentials != SECRET_TOKEN:
+        raise HTTPException(
+            status_code=status.HTTP_401_UNAUTHORIZED,
+            detail="Invalid or missing token",
+            headers={"WWW-Authenticate": "Bearer"},
+        )
+
+
+@app.get("/")
+def read_root():
+    return {"message": "Hello"}
+
+
+@app.get("/secure")
+def secure_route(credentials: HTTPAuthorizationCredentials = Depends(verify_token)):
+    return {"message": "Authenticated"}

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,3 @@
+fastapi
+uvicorn
+python-dotenv


### PR DESCRIPTION
## Summary
- add a small FastAPI backend with token authentication
- ignore `.env` and `__pycache__`
- list backend dependencies in `requirements.txt`
- document how to run the backend

## Testing
- `pip install -r requirements.txt`
- `python -m py_compile backend/main.py`

------
https://chatgpt.com/codex/tasks/task_e_6876ed8da5608326ad4b95f5a0c813a0