### PR TITLE
Add OpenAPI spec and generator

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,6 +68,15 @@ This repository includes a Visual Studio Code Dev Containers / GitHub Codespaces
 
 Docker / the Codespace should have at least **4 Cores and 6 GB of RAM (8 GB recommended)** to run full build. See the [development container README](.devcontainer/README.md) for more information.
 
+## API Documentation
+
+The OpenAPI specification for the sample FastAPI app lives in `agent-suite/docs/api_docs.json`.
+To regenerate this file, run:
+
+```bash
+python agent-suite/docs/generate_api_docs.py
+```
+
 ## Code of Conduct
 
 This project has adopted the [Microsoft Open Source Code of Conduct](https://opensource.microsoft.com/codeofconduct/). For more information see the [Code of Conduct FAQ](https://opensource.microsoft.com/codeofconduct/faq/) or contact [opencode@microsoft.com](mailto:opencode@microsoft.com) with any additional questions or comments.

--- a/agent-suite/docs/api_docs.json
+++ b/agent-suite/docs/api_docs.json
@@ -1,0 +1,25 @@
+{
+  "openapi": "3.0.2",
+  "info": {
+    "title": "Agent Suite API",
+    "version": "1.0.0"
+  },
+  "paths": {
+    "/ping": {
+      "get": {
+        "summary": "Ping",
+        "operationId": "ping_ping_get",
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {}
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+}

--- a/agent-suite/docs/generate_api_docs.py
+++ b/agent-suite/docs/generate_api_docs.py
@@ -1,0 +1,17 @@
+from fastapi import FastAPI
+from fastapi.openapi.utils import get_openapi
+import json
+import os
+
+app = FastAPI(title="Agent Suite API", version="1.0.0")
+
+@app.get("/ping")
+def ping():
+    return {"ping": "pong"}
+
+if __name__ == "__main__":
+    schema = get_openapi(title=app.title, version=app.version, routes=app.routes)
+    out_path = os.path.join(os.path.dirname(__file__), "api_docs.json")
+    with open(out_path, "w") as f:
+        json.dump(schema, f, indent=2)
+    print(f"OpenAPI spec written to {out_path}")


### PR DESCRIPTION
## Summary
- add a small FastAPI generator to produce `api_docs.json`
- include generated OpenAPI spec in `agent-suite/docs`
- document how to regenerate the API spec in `README.md`

## Testing
- `python agent-suite/docs/generate_api_docs.py`


------
https://chatgpt.com/codex/tasks/task_e_6876ed890c108326a110cd32a00d5f97